### PR TITLE
Fix cacheutils path & cast

### DIFF
--- a/cacheutils.h
+++ b/cacheutils.h
@@ -73,7 +73,7 @@ void* map_file(const char* filename, map_handle_t** handle) {
     return NULL;
   }
 
-  *handle = calloc(1, sizeof(map_handle_t));
+  *handle = (map_handle_t*) calloc(1, sizeof(map_handle_t));
   if (*handle == NULL) {
     return NULL;
   }

--- a/profiling_aes_example/Makefile
+++ b/profiling_aes_example/Makefile
@@ -1,5 +1,5 @@
 all: spy
 clean:
 	rm -f *.o spy
-spy: spy.cpp ../../cacheutils.h
+spy: spy.cpp ../cacheutils.h
 	g++ -std=gnu++11 -O2 -o $@ $< -Iopenssl -L./ -lcrypto

--- a/profiling_aes_example/spy.cpp
+++ b/profiling_aes_example/spy.cpp
@@ -6,7 +6,7 @@
 #include <fcntl.h>
 #include <sched.h>
 #include <sys/mman.h>
-#include "../../cacheutils.h"
+#include "../cacheutils.h"
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
- Without path update Makefile in /profling_aes_esample didn't work.
- Without (map_handle_t*) cast code didn't compile.